### PR TITLE
Wrapper helper_method call in action_controller_extension.rb to avoid storytime issue

### DIFF
--- a/lib/leather/action_controller_extension.rb
+++ b/lib/leather/action_controller_extension.rb
@@ -4,7 +4,9 @@ module Leather
 
     included do
       extend        ClassMethods
-      helper_method :current_tab, :current_tab? if respond_to?(:helper_method)
+      if respond_to?(:helper_method)
+        helper_method :current_tab, :current_tab? if respond_to?(:helper_method)
+      end
     end
 
     protected


### PR DESCRIPTION
issue:  https://github.com/CultivateLabs/storytime/issues/206.

Like @testa19 reported, the problem could be in gem `leather-3.5.1`. I found a possible solution https://github.com/Envek/monban/commit/581698f68e277866018c0448fcb28c0f97bdbb2c.

I modified : 
`/usr/local/lib/ruby/gems/2.4.0/gems/leather-3.5.1/lib/leather/action_controller_extension.rb` 

like the above link indicates:

* Original
```
helper_method :current_tab, :current_tab?
```
* Modified
```
if respond_to?(:helper_method)
    helper_method :current_tab, :current_tab?
end 
```

and the bug disappeared.

Since [storytime adopted the fork version of dvanderbeek/leather](https://github.com/CultivateLabs/storytime/blob/b4f477de653e906e03b7eb3beb22c619022c62cf/Gemfile#L17) , I think it would be fine to modified leather source code.